### PR TITLE
Limit visible codes by date

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -65,13 +65,15 @@ class ClassifyForm(FlaskForm):
         codes_form = cls()
 
         # Extract codes from Postgres
+        # Where there is not and end date yet
 
-        codes = Codes.query.all()
+        codes = Codes.query.filter(Codes.end_date == None).all()
         codes_form.code.choices = [(g.code_id, g.code) for g in codes]
         
         # Extract project_codes from Postgres
+        # Where there is not and end date yet
 
-        project_codes = ProjectCodes.query.all()
+        project_codes = ProjectCodes.query.filter(Codes.end_date == None).all()
         codes_form.project_code.choices = [(i.project_code_id, i.project_code) for i in project_codes]
 
         return(codes_form)

--- a/app/models.py
+++ b/app/models.py
@@ -357,7 +357,7 @@ class Codes(db.Model):
     @staticmethod
     def generate_fake(count=10):
         from sqlalchemy.exc import IntegrityError
-        from random import seed, randint
+        from random import seed, randint, choice
         import forgery_py
 
         seed()
@@ -369,7 +369,7 @@ class Codes(db.Model):
             code='none',
             description='none',
             start_date=forgery_py.date.date(True),
-            end_date=forgery_py.date.date(True)
+            end_date=None
             )
 
         db.session.add(r)
@@ -383,7 +383,7 @@ class Codes(db.Model):
                 code=forgery_py.lorem_ipsum.word(),
                 description=forgery_py.lorem_ipsum.sentence(),
                 start_date=forgery_py.date.date(True),
-                end_date=forgery_py.date.date(True)
+                end_date=choice([None,forgery_py.date.date(True)])
                 )
 
             db.session.add(r)
@@ -408,7 +408,7 @@ class ProjectCodes(db.Model):
     @staticmethod
     def generate_fake(count=3):
         from sqlalchemy.exc import IntegrityError
-        from random import seed, randint
+        from random import seed, randint, choice
         import forgery_py
 
         seed()
@@ -420,7 +420,7 @@ class ProjectCodes(db.Model):
             project_code='none',
             description='none',
             start_date=forgery_py.date.date(True),
-            end_date=forgery_py.date.date(True)
+            end_date=None
             )
 
         db.session.add(r)
@@ -434,7 +434,7 @@ class ProjectCodes(db.Model):
                 project_code=forgery_py.lorem_ipsum.word(),
                 description=forgery_py.lorem_ipsum.sentence(),
                 start_date=forgery_py.date.date(True),
-                end_date=forgery_py.date.date(True)
+                end_date=choice([None,forgery_py.date.date(True)])
                 )
 
             db.session.add(r)


### PR DESCRIPTION
Hide dates that have been retired by adding a filter on codes.end_date. Update the generate_fake() methods to create a random selection of current and retired codes and project_codes.