### PR TITLE
Performance improvements

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -37,7 +37,11 @@ def server_shutdown():
 
 def new_survey(user, model):
 
-    priority = model.query.filter(Priority.priority<8).all()
+    # This query can be slow is slow.
+    # Filter by 7 will remove all recalcitrant surveys, pii, 
+    # And those already happily classified.
+
+    priority = model.query.filter(Priority.priority<7).all()
 
     priority_list = [i for i in priority if i.coders is None or user not in i.coders]
     

--- a/sql/prioritydash/classified_latest.sql
+++ b/sql/prioritydash/classified_latest.sql
@@ -8,4 +8,4 @@ left join users
 on (classified.coder_id=users.id) 
 order by date_coded 
 desc limit 10;
-\watch 0.2
+\watch 1

--- a/sql/prioritydash/priority_count.sql
+++ b/sql/prioritydash/priority_count.sql
@@ -1,2 +1,2 @@
 select priority, count(*) from priority group by priority;
-\watch 0.2
+\watch 1

--- a/sql/prioritydash/priority_view.sql
+++ b/sql/prioritydash/priority_view.sql
@@ -1,2 +1,2 @@
 select * from priority order by priority, ratio limit 15;
-\watch 0.2
+\watch 1

--- a/sql/views/priority.sql
+++ b/sql/views/priority.sql
@@ -31,6 +31,8 @@ full outer join raw
 on (a.respondent_id = raw.respondent_id)
 --where raw.start_date > '2017-04-21'
 group by (raw.respondent_id, a.code_id)
+order by raw.start_date desc
+limit 6000
 ),
 -- Now calculate how many times a survey has been classified
 total_codes as (


### PR DESCRIPTION
Running a classification from the index page was resulting in a query that took up to second. Changes here mean that:

* Only the most recent 6000 surveys will be returned into the priority view (this can easily be changed by editing priority.sql)
* The update rate of the watch queries in sql/prioritydash is reduced to one second from 0.2 seconds, haveing three queries accessing the priority view 5 times a second was creating a drain on the server.
* Finally, some additional improvements to the Classified.generate_fake() method to make it more like a human coding session.