### PR TITLE
Convert DataRequired to InputRequired (Closes #62)

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, TextAreaField, BooleanField, SelectField, SubmitField, RadioField
-from wtforms.validators import DataRequired, Length, Email, Regexp
+from wtforms.validators import DataRequired, Length, Email, Regexp, InputRequired
 from wtforms import ValidationError
 from flask_pagedown.fields import PageDownField
 from ..models import Role, User, Codes, ProjectCodes, Classified
@@ -48,13 +48,13 @@ class EditProfileAdminForm(FlaskForm):
             raise ValidationError('Username already in use.')
 
 class ClassifyForm(FlaskForm):
-    code = RadioField('code_radio', coerce=int, validators=[DataRequired()])
+    code = RadioField('code_radio', coerce=int, validators=[InputRequired()])
 
     # Default the project code to 1, which should correspond to 'none'
     # Better solution would be to determine this dynamically.
     # Using ProjectCode.query.filter_by(project_code='none').first()
 
-    project_code = RadioField('project_code_radio', coerce=int, default='0', validators=[DataRequired()])
+    project_code = RadioField('project_code_radio', coerce=int, default='0', validators=[InputRequired()])
 
     PII_boolean = BooleanField('PII_boolean')
 

--- a/migrations/versions/7b6db31373a3_.py
+++ b/migrations/versions/7b6db31373a3_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: c83729c89803
+Revision ID: 7b6db31373a3
 Revises: 
-Create Date: 2017-04-19 17:58:49.488698
+Create Date: 2017-04-25 13:12:54.741194
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'c83729c89803'
+revision = '7b6db31373a3'
 down_revision = None
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Changing from Required to DataRequired results in failures when submitting values of 0 in forms. This can be fixed by instead using InputRequired (which checks pre-coersion) and will allow zero values.

Also update migrations.