### PR TITLE
Add dates, passport, and NHS to pii removal

### DIFF
--- a/app/piiremover.py
+++ b/app/piiremover.py
@@ -1,11 +1,11 @@
 from re import sub, compile
 
-ni = compile('[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?')
-phone = compile('(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?')
-vrp = compile('((?:[a-zA-Z]{2}\s?[0-9]{2}\s?[a-zA-Z]{3})|(?:[a-zA-Z]{3}\s?\d{4}))')
-passports = compile('[0-9]{9,10}GBR[0-9]{7}[U,M,F]{1}[0-9]{7}')
-dates = compile('((?:\d{1,2})(?:rd|nd|th)?([\/\.\-\ ])((?:[0-9]{1,2})|(?:\D{3})|(?:January|February|March|April|May|June|July|August|Septeber|October|November|December))(?:[\/\.\-\ ])\d{2,4})')
-digits = compile('\d')
+ni = '[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?'
+phone = '(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?'
+vrp = '((?:[a-zA-Z]{2}\s?[0-9]{2}\s?[a-zA-Z]{3})|(?:[a-zA-Z]{3}\s?\d{4}))'
+passports = '[0-9]{9,10}GBR[0-9]{7}[U,M,F]{1}[0-9]{7}'
+dates = '((?:\d{1,2})(?:rd|nd|th)?([\/\.\-\ ])((?:[0-9]{1,2})|(?:\D{3})|(?:January|February|March|April|May|June|July|August|Septeber|October|November|December))(?:[\/\.\-\ ])\d{2,4})'
+digits = '\d'
 
 def pii_remover(
         x, 

--- a/app/piiremover.py
+++ b/app/piiremover.py
@@ -3,7 +3,9 @@ from re import sub, compile
 ni = compile('[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?')
 phone = compile('(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?')
 vrp = compile('((?:[a-zA-Z]{2}\s?[0-9]{2}\s?[a-zA-Z]{3})|(?:[a-zA-Z]{3}\s?\d{4}))')
-credit_cards = compile('(?:\d[ -]*?){13,16}')
+passports = compile('[0-9]{9,10}GBR[0-9]{7}[U,M,F]{1}[0-9]{7}')
+dates = compile('((?:\d{1,2})(?:rd|nd|th)?([\/\.\-\ ])((?:[0-9]{1,2})|(?:\D{3})|(?:January|February|March|April|May|June|July|August|Septeber|October|November|December))(?:[\/\.\-\ ])\d{2,4})')
+digits = compile('\d')
 
 def pii_remover(
         x, 
@@ -11,17 +13,30 @@ def pii_remover(
         ni = ni,
         phone = phone,
         vrp = vrp,
-        credit_cards = credit_cards
+        passports = passports,
+        dates = dates,
+        digits = digits
         ):
 
     '''
     Find most common forms of PII and replace with [PII Removed]
     Order is important in terms of what is searched for first.
+    Matches can conflict, but any remaining nmatched digits are
+    replaced with X.
+
+    Sources:
+
+    Passports: http://regexlib.com/REDetails.aspx?regexp_id=2390
+    NHS and short passport numbers will be caught be credit cards regex.
+
     '''
 
-    if credit_cards:
-        x = sub(credit_cards, replace, x)
-
+    if passports:
+        x = sub(passports, replace, x)
+    
+    if dates:
+        x = sub(dates, replace, x)
+    
     if phone:
         x = sub(phone, replace, x)
 
@@ -30,5 +45,9 @@ def pii_remover(
 
     if vrp:
         x = sub(vrp, replace, x)
+
+    # Enforce catch-all for all remaining digits
+
+    x = sub(digits, 'X', x)
 
     return x

--- a/app/piiremover.py
+++ b/app/piiremover.py
@@ -4,7 +4,7 @@ ni = '[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?'
 phone = '(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\#(\d{4}|\d{3}))?'
 vrp = '((?:[a-zA-Z]{2}\s?[0-9]{2}\s?[a-zA-Z]{3})|(?:[a-zA-Z]{3}\s?\d{4}))'
 passports = '[0-9]{9,10}GBR[0-9]{7}[U,M,F]{1}[0-9]{7}'
-dates = '((?:\d{1,2})(?:rd|nd|th)?([\/\.\-\ ])((?:[0-9]{1,2})|(?:\D{3})|(?:January|February|March|April|May|June|July|August|Septeber|October|November|December))(?:[\/\.\-\ ])\d{2,4})'
+dates = '((?:\d{1,2})(?:rd|nd|th)?([\/\.\-\ ])((?:[0-9]{1,2})|(?:\D{3})|(?:January|February|March|April|May|June|July|August|September|October|November|December))(?:[\/\.\-\ ])\d{2,4})'
 digits = '\d'
 
 def pii_remover(

--- a/tests/test_piiremover.py
+++ b/tests/test_piiremover.py
@@ -57,7 +57,7 @@ class TestPIIRemoval(unittest.TestCase):
         for i in test_cases:
 
             feedback = 'This is not a real vehicle registration plate number %s!' % i
-
+            
             self.assertTrue(pii_remover(feedback) == success)           
 
 

--- a/tests/test_piiremover.py
+++ b/tests/test_piiremover.py
@@ -4,74 +4,107 @@ from flask import current_app
 from app.piiremover import pii_remover
 from app.models import Raw, Urls
 
-def test_pii_remover_works_with_no_pii(self):
-
-    no_pii = 'This string does not contain pii'   
-    self.assertTrue(pii_remover(no_pii) == no_pii)
-
-def test_pii_remover_catches_NI_numbers(self): 
-        
-    test_cases = ['QQ123456C','QQ 123456 C','QQ 12 34 56 C',
-            'QQ123456','QQ 123456','QQ 12 34 56']
-        
-    success = 'This is not a real national insurance number %s!' % '[PII Removed]'
-        
-    for i in test_cases:
-
-        feedback = 'This is not a real national insurance number %s!' % i
-
-        self.assertTrue(pii_remover(feedback) == success)           
-
-            
-def test_pii_remover_catches_phone_numbers(self): 
-        
-    '''
-    See this link for details on generating fake phone numbers
-    https://www.ofcom.org.uk/phones-telecoms-and-internet/
-    information-for-industry/numbering/numbers-for-drama
-    '''
-
-    test_cases = ['02079461234','0207 946 1234','+442079461234',
-        '07700 900123','+447700900123','08081 570123','0909 8790123',
-        '(03069) 990123','03069 990123']
-    
-    success = 'This is not a real telephone number %s!' % '[PII Removed]'
-    
-    for i in test_cases:
-
-        feedback = 'This is not a real telephone number %s!' % i
-
-        self.assertTrue(pii_remover(feedback) == success)           
-
-
-def test_pii_remover_catches_credit_card_numbers(self): 
-    
-    test_cases = ['1234567890123456','1234567890123']
-    
-    success = 'This is not a real credit card number %s!' % '[PII Removed]'
-    
-    for i in test_cases:
-
-        feedback = 'This is not a real credit card number %s!' % i
-
-        self.assertTrue(pii_remover(feedback) == success)           
-
-def test_pii_remover_catches_vehicle_reg_plates(self): 
-    
-    '''
-    '''
-
-    test_cases = ['AB12ABC','AB12 ABC']
-    
-    success = 'This is not a real vehicle registration plate number %s!' % '[PII Removed]'
-    
-    for i in test_cases:
-
-        feedback = 'This is not a real vehicle registration plate number %s!' % i
-
-        self.assertTrue(pii_remover(feedback) == success)           
-
 class TestPIIRemoval(unittest.TestCase):
+
+    def test_pii_remover_works_with_no_pii(self):
+
+        no_pii = 'This string does not contain pii'   
+        self.assertTrue(pii_remover(no_pii) == no_pii)
+
+    def test_pii_remover_catches_NI_numbers(self): 
+            
+        test_cases = ['QQ123456C','QQ 123456 C','QQ 12 34 56 C',
+                'QQ123456','QQ 123456','QQ 12 34 56']
+            
+        success = 'This is not a real national insurance number %s!' % '[PII Removed]'
+            
+        for i in test_cases:
+
+            feedback = 'This is not a real national insurance number %s!' % i
+
+            self.assertTrue(pii_remover(feedback, dates=None) == success)           
+
+                
+    def test_pii_remover_catches_phone_numbers(self): 
+            
+        '''
+        See this link for details on generating fake phone numbers
+        https://www.ofcom.org.uk/phones-telecoms-and-internet/
+        information-for-industry/numbering/numbers-for-drama
+        '''
+
+        test_cases = ['02079461234','0207 946 1234','+442079461234',
+            '07700 900123','+447700900123','08081 570123','0909 8790123',
+            '(03069) 990123','03069 990123']
+        
+        success = 'This is not a real telephone number %s!' % '[PII Removed]'
+        
+        for i in test_cases:
+
+            feedback = 'This is not a real telephone number %s!' % i
+
+            self.assertTrue(pii_remover(feedback) == success)           
+
+    def test_pii_remover_catches_vehicle_reg_plates(self): 
+        
+        '''
+        '''
+
+        test_cases = ['AB12ABC','AB12 ABC']
+        
+        success = 'This is not a real vehicle registration plate number %s!' % '[PII Removed]'
+        
+        for i in test_cases:
+
+            feedback = 'This is not a real vehicle registration plate number %s!' % i
+
+            self.assertTrue(pii_remover(feedback) == success)           
+
+
+    def test_pii_remover_catches_GB_passports(self): 
+        
+        '''
+        Passport specimen source:
+        https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/473495/HMPO_magazine.pdf
+        '''
+
+        test_cases = ['5333800068GBR8812049F2509286']
+        
+        success = 'This: %s is a specimen passport number.' % '[PII Removed]'
+        
+        for i in test_cases:
+
+            feedback = 'This: %s is a specimen passport number.' % i
+
+            self.assertTrue(pii_remover(feedback) == success)
+
+
+    def test_pii_remover_catches_dates(self): 
+        
+        '''
+        '''
+
+        test_cases = ['21/10/1964','21-12-2067','12 01 1876','12 Feb 2061']
+        
+        success = 'This: %s is a specimen date.' % '[PII Removed]'
+        
+        for i in test_cases:
+
+            feedback = 'This: %s is a specimen date.' % i
+ 
+            self.assertTrue(pii_remover(feedback) == success)
+
+    def test_pii_remover_redacts_digits(self): 
+        
+        '''
+        '''
+
+        feedback = 'This is a test (%s) with some redacted numbers (%s), and %s.' % ('1', '23', '456')
+        success = 'This is a test (%s) with some redacted numbers (%s), and %s.' % ('X', 'XX', 'XXX')
+        
+        self.assertTrue(pii_remover(feedback) == success)
+
+class TestPIIRemovalOnDB(unittest.TestCase):
 
     def setUp(self):
         
@@ -86,9 +119,8 @@ class TestPIIRemoval(unittest.TestCase):
         national_insurance = Raw(comment_further_comments=comment + 'QQ123456Q' + further_comment)
         phone_number = Raw(comment_further_comments=comment + '02079461234' + further_comment)
         vrp = Raw(comment_further_comments=comment + 'AB12 ABC' + further_comment)
-        credit_card = Raw(comment_further_comments=comment + '1234567891234567' + further_comment)
  
-        objects = [national_insurance, phone_number, vrp, credit_card]
+        objects = [national_insurance, phone_number, vrp]
         db.session.bulk_save_objects(objects)
         db.session.commit()        
 


### PR DESCRIPTION
Update `pii_remover()` to include some additional cases:

* Long passport numbers
* Short passport numbers, NHS numbers (included in credit_cards) check
* Finally, all unmatched digits are converted to 'X'

On consultation with the team involved, we agreed that there are few if any cases where a user would be recording any relevant information as digits, and that since these were most likely to correspond with PII, they should simply be redacted. This provides an effective catch-all for the `pii_remover()` function.