### PR TITLE
Set runtime to python 3.6.2

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.2


### PR DESCRIPTION
Following GOV.UK PaaS guidance: switch to Python version 3.6.2.