### PR TITLE
Add retired user role 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,8 @@ from random import choice
 class Permission:
     CLASSIFY = 0x01
     GAMIFY = 0x02
-    ADMINISTER = 0x80
+    ADMINISTER = 0xff
+    RETIRED = 0x00
 
 
 class Role(db.Model):
@@ -33,7 +34,8 @@ class Role(db.Model):
         roles = {
             'User': (Permission.CLASSIFY, False),
             'User-Gamify': (Permission.CLASSIFY | Permission.GAMIFY, False),
-            'Administrator': (0xff, False)
+            'Administrator': (Permission.RETIRED, False),
+            'Retired': (Permission.RETIRED, False)
         }
         for r in roles:
             role = Role.query.filter_by(name=r).first()

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,7 @@ class Role(db.Model):
         roles = {
             'User': (Permission.CLASSIFY, False),
             'User-Gamify': (Permission.CLASSIFY | Permission.GAMIFY, False),
-            'Administrator': (Permission.RETIRED, False),
+            'Administrator': (Permission.ADMINISTER, False),
             'Retired': (Permission.RETIRED, False)
         }
         for r in roles:

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,7 @@ coverage:
     - configy.py
     - manage.py
     - */__init__.py
+    - */site-packages/*
 
 comment:
   layout: "header, diff, changes"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+    i
+# This file represents the default values when a customer has not filled them out
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  notify:
+    require_ci_to_pass: yes
+
+  status:
+    project: yes
+
+    patch: yes
+
+    changes: yes
+
+  ignore: # files and folders for processing
+    - tests/*
+    - configy.py
+    - manage.py
+    - */__init__.py
+
+comment:
+  layout: "header, diff, changes"
+  behavior: default
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,27 +1,15 @@
-    i
-# This file represents the default values when a customer has not filled them out
-coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-  notify:
-    require_ci_to_pass: yes
-
-  status:
-    project: yes
-
-    patch: yes
-
-    changes: yes
-
-  ignore: # files and folders for processing
-    - tests/*
-    - configy.py
-    - manage.py
-    - */__init__.py
-    - */site-packages/*
+codecov:
+    notify:
+        require_ci_to_pass: no
 
 comment:
-  layout: "header, diff, changes"
-  behavior: default
+    layout: header, changes, diff
+
+coverage:
+    ignore:
+        - tests/*
+        - config.py
+        - manage.py
+        - */__init__.py
+        - */site-packages/*
   

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import sys
 
 COV = None
 if os.environ.get('FLASK_COVERAGE'):
@@ -47,7 +48,6 @@ manager.add_command('db', MigrateCommand)
 def test(coverage=False):
     """Run the unit tests."""
     if coverage and not os.environ.get('FLASK_COVERAGE'):
-        import sys
         os.environ['FLASK_COVERAGE'] = '1'
         os.execvp(sys.executable, [sys.executable] + sys.argv)
     import unittest

--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
 import os
+import coverage
 import sys
+import unittest
+from flask_migrate import upgrade, Migrate, MigrateCommand
+from app.queryloader import query_loader
+from app import create_app, db
+from app.models import (User, Role, Permission, Codes, Raw, ProjectCodes, 
+        Classified, Priority, Urls)
+from flask_script import Manager, Shell
+from werkzeug.contrib.profiler import ProfilerMiddleware
 
 COV = None
 if os.environ.get('FLASK_COVERAGE'):
-    import coverage
     COV = coverage.coverage(branch=True, include='app/*')
     COV.start()
 
@@ -15,10 +23,6 @@ if os.path.exists('.env'):
         if len(var) == 2:
             os.environ[var[0]] = var[1]
 
-from app import create_app, db
-from app.models import User, Role, Permission, Codes, Raw, ProjectCodes, Classified, Priority, Urls
-from flask_script import Manager, Shell
-from flask_migrate import Migrate, MigrateCommand
 
 app = create_app(os.getenv('FLASK_CONFIG') or 'default')
 manager = Manager(app)
@@ -50,7 +54,6 @@ def test(coverage=False):
     if coverage and not os.environ.get('FLASK_COVERAGE'):
         os.environ['FLASK_COVERAGE'] = '1'
         os.execvp(sys.executable, [sys.executable] + sys.argv)
-    import unittest
     tests = unittest.TestLoader().discover('tests')
     result = unittest.TextTestRunner(verbosity=2).run(tests)
     if not result.wasSuccessful():
@@ -69,7 +72,6 @@ def test(coverage=False):
 @manager.command
 def profile(length=25, profile_dir=None):
     """Start the application under the code profiler."""
-    from werkzeug.contrib.profiler import ProfilerMiddleware
     app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[length],
                                       profile_dir=profile_dir)
     app.run()
@@ -84,11 +86,7 @@ def deploy_local():
 @manager.command
 def deploy():
     """Run deployment tasks."""
-    from flask_migrate import upgrade
-    from app.models import Role, User
-    from app.queryloader import query_loader
     # migrate database to latest revision
-
     upgrade()
 
     # create user roles
@@ -106,16 +104,11 @@ def deploy():
 @manager.command
 def populate():
     """Populate database with fake data."""
-    from flask_migrate import upgrade
-    from app.models import Role, User, Codes, ProjectCodes, Classified
-    # migrate database to latest revision
 
-    # create user roles
     Raw.generate_fake(1000)
     Codes.generate_fake()
     ProjectCodes.generate_fake()
     User.generate_fake(10)
-
     Classified.generate_fake(500, 10)
 
 if __name__ == '__main__':

--- a/sql/views/leaders.sql
+++ b/sql/views/leaders.sql
@@ -8,7 +8,7 @@ create view leaders as (
         from Classified 
         left join users
         on users.id=classified.coder_id
-        where users.role_id != (select id from roles where roles.name = 'User')
+        where users.role_id not in (select id from roles where roles.name in ('User','Retired'))
         group by coder_id
     )
     select row_number() over (order by cte.n desc) as rank, users.username, cte.n 
@@ -23,7 +23,7 @@ create view daily_leaders as (
     from classified 
     left join users
     on users.id=classified.coder_id
-    where users.role_id != (select id from roles where roles.name = 'User')
+    where users.role_id not in (select id from roles where roles.name in ('User','Retired'))
     and date_coded > (select date_trunc('day', now()))
     group by coder_id
     )
@@ -39,7 +39,7 @@ create view weekly_leaders as (
     from classified 
     left join users
     on users.id=classified.coder_id
-    where users.role_id != (select id from roles where roles.name = 'User')
+    where users.role_id not in (select id from roles where roles.name in ('User','Retired'))
     and date_coded > (select date_trunc('week', now()) -INTERVAL '1 day')
     group by coder_id
     )


### PR DESCRIPTION
Old users who are no longer classifying surveys should remain in the database to keep the foreign key constraint on the classified table, but also need to have no permissions.