### PR TITLE
Add .cfignore as a symbolic link to .gitignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,5 @@ pyvenv.cfg
 share
 
 # CloudFoundry
-.cfignore
 manifest.yml
 *.sh


### PR DESCRIPTION
This is already documented in the readme.

Done as per the [paas docs suggestion](https://docs.cloud.service.gov.uk/#excluding-files). I assume this link was missed in a previous checkin.