### PR TITLE
Fix for .env being loaded for manage.py commands

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,6 @@ from flask_moment import Moment
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_pagedown import PageDown
-from config import config
 
 bootstrap = Bootstrap()
 moment = Moment()
@@ -18,6 +17,9 @@ login_manager.login_view = 'auth.login'
 
 def create_app(config_name):
     app = Flask(__name__)
+    # import config here rather than at module level to ensure that .env values
+    # are loaded into the environment first when running manage.py
+    from config import config
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
 


### PR DESCRIPTION
I guess you have your terminal to load .env files automatically (autoenv installed), but config does load it and this fix saves autoenv being necessary.